### PR TITLE
Refactor: FE, BE, Add timezone in cookie #16

### DIFF
--- a/alpha-admin/src/users/controllers/AuthProvider.js
+++ b/alpha-admin/src/users/controllers/AuthProvider.js
@@ -1,4 +1,5 @@
 import { Cookies } from "react-cookie";
+import moment from "moment-timezone";
 
 const cookies = new Cookies();
 
@@ -20,6 +21,10 @@ const authProvider = {
     return fetch(request)
       .then((response) => {
         if (response.ok) {
+          cookies.set("tz", encodeURIComponent(moment.tz.guess()), {
+            path: "/",
+            expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14),
+          });
           return Promise.resolve();
         } else if (response.status < 200 || response.status >= 300) {
           return Promise.reject();
@@ -33,6 +38,17 @@ const authProvider = {
   checkAuth: async () => {
     if (!cookies.get("loggedIn")) {
       return Promise.reject();
+    }
+    // timezone 쿠키가 존재하지 않거나, timezone이 올바르지 않을 경우
+    // timezone 쿠키를 새로운 값으로 갱신, 유효기간 14일
+    if (
+      !cookies.get("tz") ||
+      !moment.tz(decodeURIComponent(cookies.get("tz"))).isValid()
+    ) {
+      cookies.set("tz", encodeURIComponent(moment.tz.guess()), {
+        path: "/",
+        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14),
+      });
     }
 
     const request = new Request(

--- a/backend/controllers/events-controllers.js
+++ b/backend/controllers/events-controllers.js
@@ -231,7 +231,7 @@ const getEventsByMonth = async (req, res, next) => {
   const inputCalendar = req.params.calendarId;
   const inputStartDate = req.params.date.split("~")[0];
   const inputEndDate = req.params.date.split("~")[1];
-  const timezone = decodeURIComponent(req.params.timezone);
+  const timezone = decodeURIComponent(req.cookies.tz);
 
   // 입력된 날짜와 타임존이 유효한지 확인
   if (
@@ -291,7 +291,7 @@ const getEventsByMonth = async (req, res, next) => {
 const getIntersectionEventsByDay = async (req, res, next) => {
   const inputCalendar = req.params.calendarId;
   const inputDate = req.params.date;
-  const timezone = decodeURIComponent(req.params.timezone);
+  const timezone = decodeURIComponent(req.cookies.tz);
 
   // 입력된 날짜와 타임존이 유효한지 확인
   if (!moment.tz(inputDate, timezone).isValid()) {
@@ -380,7 +380,7 @@ const getIntersectionEventsByDay = async (req, res, next) => {
   }
 
   res
-    .status(201)
+    .status(200)
     .json({ events: events, intersection: intersectionJson.slice(0, 6) });
 
   // events 변수 자체가 커서인듯...
@@ -438,7 +438,7 @@ const getIntersectionEventsByMonth = async (req, res, next) => {
   const inputCalendar = req.params.calendarId;
   const inputStartDate = req.params.date.split("~")[0];
   const inputEndDate = req.params.date.split("~")[1];
-  const timezone = decodeURIComponent(req.params.timezone);
+  const timezone = decodeURIComponent(req.cookies.tz);
 
   // 년월, Timezone 정보가 올바른지 확인
   if (
@@ -561,7 +561,7 @@ const getIntersectionEventsByMonth = async (req, res, next) => {
   console.log(intersectionByMonthJson);
 
   // 이벤트 전역변수 출력
-  res.status(201).json({ events: intersectionByMonthJson });
+  res.status(200).json({ events: intersectionByMonthJson });
 };
 
 const createEvents = async (req, res, next) => {
@@ -688,7 +688,7 @@ const createEvents = async (req, res, next) => {
     return next(error);
   }
 
-  res.status(201).json({ events: insertEventsArray, conflict: conflictTime });
+  res.status(200).json({ events: insertEventsArray, conflict: conflictTime });
 
   // data validation
 

--- a/backend/middleware/check-auth.js
+++ b/backend/middleware/check-auth.js
@@ -114,6 +114,10 @@ module.exports = async (req, res, next) => {
         .cookie("loggedIn", 1, {
           path: "/",
           expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14),
+        })
+        .cookie("tz", req.cookies.tz, {
+          path: "/",
+          expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14),
         });
     }
 

--- a/backend/routes/events-routes.js
+++ b/backend/routes/events-routes.js
@@ -10,15 +10,15 @@ router.use(checkAuth);
 // 테스트용
 router.get("/", eventsControllers.getEvents);
 router.get(
-  "/calendar/:calendarId/int-day/:date/:timezone",
+  "/calendar/:calendarId/int-day/:date",
   eventsControllers.getIntersectionEventsByDay
 );
 router.get(
-  "/calendar/:calendarId/int-month/:date/:timezone",
+  "/calendar/:calendarId/int-month/:date",
   eventsControllers.getIntersectionEventsByMonth
 );
 router.get(
-  "/calendar/:calendarId/one-user-month/:date/:timezone",
+  "/calendar/:calendarId/one-user-month/:date",
   eventsControllers.getEventsByMonth
 );
 

--- a/backend/test/events-controllers.test.js
+++ b/backend/test/events-controllers.test.js
@@ -166,17 +166,20 @@ describe("GET /api/events/calendar/:calendarId/one-user-month/:date/:timezone", 
       .send({ email: "hhh1@hhh.com", password: "123123" });
 
     const cookie = loginResponse.headers["set-cookie"];
+    cookie.push(
+      `tz=${encodeURIComponent("Asia/Seoul")}; Path=/; Expires=${new Date(
+        Date.now() + 1000 * 60 * 60 * 24 * 14
+      )}`
+    );
+    console.log(cookie);
 
-    const url =
-      `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/one-user-month/2022-01-22~2022-02-01/` +
-      encodeURIComponent("Asia/Seoul");
-
+    const url = `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/one-user-month/2022-01-22~2022-02-01/`;
     await request(app)
       .get(url)
       .set({ cookie: cookie })
       .then(async (res) => {
+        expect(res.statusCode).toBe(200);
         expect(res.body.events).toStrictEqual("");
-        expect(res.statusCode).toBe(201);
       });
   });
 });
@@ -188,16 +191,19 @@ describe("GET /api/events/calendar/:calendarId/int-day/:date/:timezone", () => {
       .send({ email: "hhh1@hhh.com", password: "123123" });
 
     const cookie = loginResponse.headers["set-cookie"];
+    cookie.push(
+      `tz=${encodeURIComponent("Asia/Seoul")}; Path=/; Expires=${new Date(
+        Date.now() + 1000 * 60 * 60 * 24 * 14
+      )}`
+    );
 
-    const url =
-      `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/int-day/2022-01-22/` +
-      encodeURIComponent("Asia/Seoul");
+    const url = `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/int-day/2022-01-22/`;
 
     await request(app)
       .get(url)
       .set({ cookie: cookie })
       .then(async (res) => {
-        expect(res.statusCode).toBe(201);
+        expect(res.statusCode).toBe(200);
         expect(res.body.events).toStrictEqual("");
         expect(res.body.intersection).toStrictEqual([
           {
@@ -323,16 +329,19 @@ describe("GET /api/events/calendar/:calendarId/int-month/:date/:timezone", () =>
       .send({ email: "hhh1@hhh.com", password: "123123" });
 
     const cookie = loginResponse.headers["set-cookie"];
+    cookie.push(
+      `tz=${encodeURIComponent("Asia/Seoul")}; Path=/; Expires=${new Date(
+        Date.now() + 1000 * 60 * 60 * 24 * 14
+      )}`
+    );
 
-    const url =
-      `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/int-month/2022-01-01/` +
-      encodeURIComponent("Asia/Seoul");
+    const url = `/api/events/calendar/5cabe64dcf0d4447fa60f5e2/int-month/2022-01-01/`;
 
     await request(app)
       .get(url)
       .set({ cookie: cookie })
       .then(async (res) => {
-        expect(res.statusCode).toBe(201);
+        expect(res.statusCode).toBe(200);
         expect(res.body.events).toStrictEqual([
           {
             depth: 3,


### PR DESCRIPTION
관련 이슈 #16 Timezone 정보를 쿠키에 저장하기

FE, `AuthProvider`
- login 시 timezone(tz) 쿠키 발급
- `checkAuth`에서 tz 쿠키 체크

BE
- `check-auth`, refresh token 갱신 시 tz 갱신
- `events-controllers` 에서 url params 의 timezone 대신 쿠키 tz를 사용하도록 변경
- `events-route` 의 URL에 있던 :timezone 을 삭제
- `events-controllers` 의 테스트 코드 구정
- get 요청의 http status code 수정 (201->200)